### PR TITLE
Proper Error handling and minor fix for g+ service

### DIFF
--- a/lib/googleplus.js
+++ b/lib/googleplus.js
@@ -22,7 +22,16 @@ module.exports = {
                 key: 'p',
                 apiVersion: 'v1',
             }
-        }, callback);
+        }, function(error, response, body) {
+            // just pass the error on to the parent handler
+            if (error || response.statusCode !== 200)
+                return callback(error, response, body);
+
+            if (body.error)
+                return callback(body.error, response, body);
+
+            return callback(error, response, body);
+        });
     },
     extractCount: function(data) {
         return data.result.metadata.globalCounts.count;

--- a/lib/googleplus.js
+++ b/lib/googleplus.js
@@ -5,6 +5,10 @@ var googlePlusURL = 'https://clients6.google.com/rpc?key=AIzaSyCKSbrvQasunBoV16z
 module.exports = {
     name: "googleplus",
     request: function(url, callback) {
+        // g+ requires protocol to be included
+        if (!/^https?\/\//.test(url))
+            url = 'http://' + url;
+
         return request({
             uri:    googlePlusURL,
             method: 'POST',

--- a/server.js
+++ b/server.js
@@ -46,7 +46,7 @@ server.method('getJSONOutput', function(resourceURL, next) {
                     }
 
                 } else {
-                    reject(Error(error));
+                    reject(error);
                 }
             });
         });
@@ -68,9 +68,17 @@ server.method('getJSONOutput', function(resourceURL, next) {
         });
     }
 
-    Promise.all(requests).then(extractCounts).then(toJSON).then(function(jsonOutput) {
-        next(null, jsonOutput);
-    });
+    Promise
+        .all(requests)
+        .catch(function(error) {
+            console.log(require('util').inspect(error));
+            next(error);
+        })
+        .then(extractCounts)
+        .then(toJSON)
+        .then(function(jsonOutput) {
+            next(null, jsonOutput);
+        });
 
 }, {
     cache: {
@@ -89,7 +97,10 @@ server.route({
         }
 
         server.methods.getJSONOutput(resourceURL, function(err, jsonOutput) {
-            reply(jsonOutput).type('application/json');
+            if (err)
+                reply(!(err instanceof Error) ? new Error(err) : err, null);
+            else
+                reply(jsonOutput).type('application/json');
         });
     }
 });


### PR DESCRIPTION
This adds proper error handling to the main route. Currently it would just timeout if something would fail, because Promises were broken (and also because g+ doesn't set the right response status).

It also tests if a protocol is given for the requested url for g+, which fixes the sample in the README. If none is given, g+ fails with an "Invalid Value" error.

The server now returns 500 whenever one of the services fails instead of timing out.